### PR TITLE
Enable image zoom on sliders

### DIFF
--- a/app/garaze/components/issuse-solution.tsx
+++ b/app/garaze/components/issuse-solution.tsx
@@ -10,6 +10,7 @@ import {
     type CarouselApi,
 } from "@/components/ui/carousel";
 import { useState, useEffect } from "react";
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 
 const data = {
     problem: {
@@ -88,14 +89,28 @@ function ImageCarousel({
                 <CarouselContent>
                     {images.map((image, index) => (
                         <CarouselItem key={index}>
-                            <div className="relative aspect-video">
-                                <Image
-                                    src={image.src}
-                                    alt={image.alt}
-                                    fill
-                                    className="rounded-lg object-cover"
-                                />
-                            </div>
+                            <Dialog>
+                                <DialogTrigger asChild>
+                                    <div className="relative aspect-video cursor-pointer">
+                                        <Image
+                                            src={image.src}
+                                            alt={image.alt}
+                                            fill
+                                            className="rounded-lg object-cover"
+                                        />
+                                    </div>
+                                </DialogTrigger>
+                                <DialogContent className="max-w-3xl">
+                                    <div className="relative w-full h-[80vh]">
+                                        <Image
+                                            src={image.src}
+                                            alt={image.alt}
+                                            fill
+                                            className="object-contain"
+                                        />
+                                    </div>
+                                </DialogContent>
+                            </Dialog>
                         </CarouselItem>
                     ))}
                 </CarouselContent>

--- a/app/kuchnia-salon/components/issuse-solution.tsx
+++ b/app/kuchnia-salon/components/issuse-solution.tsx
@@ -11,6 +11,7 @@ import {
     type CarouselApi,
 } from "@/components/ui/carousel";
 import { useState, useEffect } from "react";
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 
 const data = {
     problem: {
@@ -89,14 +90,28 @@ function ImageCarousel({
                 <CarouselContent>
                     {images.map((image, index) => (
                         <CarouselItem key={index}>
-                            <div className="relative aspect-video">
-                                <Image
-                                    src={image.src}
-                                    alt={image.alt}
-                                    fill
-                                    className="rounded-lg object-cover"
-                                />
-                            </div>
+                            <Dialog>
+                                <DialogTrigger asChild>
+                                    <div className="relative aspect-video cursor-pointer">
+                                        <Image
+                                            src={image.src}
+                                            alt={image.alt}
+                                            fill
+                                            className="rounded-lg object-cover"
+                                        />
+                                    </div>
+                                </DialogTrigger>
+                                <DialogContent className="max-w-3xl">
+                                    <div className="relative w-full h-[80vh]">
+                                        <Image
+                                            src={image.src}
+                                            alt={image.alt}
+                                            fill
+                                            className="object-contain"
+                                        />
+                                    </div>
+                                </DialogContent>
+                            </Dialog>
                         </CarouselItem>
                     ))}
                 </CarouselContent>

--- a/app/pomieszczenia-czyste/components/issuse-solution.tsx
+++ b/app/pomieszczenia-czyste/components/issuse-solution.tsx
@@ -11,6 +11,7 @@ import {
     type CarouselApi,
 } from "@/components/ui/carousel";
 import { useState, useEffect } from "react";
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 
 const data = {
     problem: {
@@ -89,14 +90,28 @@ function ImageCarousel({
                 <CarouselContent>
                     {images.map((image, index) => (
                         <CarouselItem key={index}>
-                            <div className="relative aspect-video">
-                                <Image
-                                    src={image.src}
-                                    alt={image.alt}
-                                    fill
-                                    className="rounded-lg object-cover"
-                                />
-                            </div>
+                            <Dialog>
+                                <DialogTrigger asChild>
+                                    <div className="relative aspect-video cursor-pointer">
+                                        <Image
+                                            src={image.src}
+                                            alt={image.alt}
+                                            fill
+                                            className="rounded-lg object-cover"
+                                        />
+                                    </div>
+                                </DialogTrigger>
+                                <DialogContent className="max-w-3xl">
+                                    <div className="relative w-full h-[80vh]">
+                                        <Image
+                                            src={image.src}
+                                            alt={image.alt}
+                                            fill
+                                            className="object-contain"
+                                        />
+                                    </div>
+                                </DialogContent>
+                            </Dialog>
                         </CarouselItem>
                     ))}
                 </CarouselContent>

--- a/app/posadzki-zywiczne-na-balkony/components/issuse-solution.tsx
+++ b/app/posadzki-zywiczne-na-balkony/components/issuse-solution.tsx
@@ -11,6 +11,7 @@ import {
     type CarouselApi,
 } from "@/components/ui/carousel"
 import { useState, useEffect } from "react"
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
 
 // Dane przykładowe - w rzeczywistości mogłyby pochodzić z CMS
 const problemImages = [
@@ -67,14 +68,28 @@ function ImageCarousel({
                 <CarouselContent>
                     {images.map((image, index) => (
                         <CarouselItem key={index}>
-                            <div className="relative aspect-video">
-                                <Image
-                                    src={image.src}
-                                    alt={image.alt}
-                                    fill
-                                    className="rounded-lg object-cover"
-                                />
-                            </div>
+                            <Dialog>
+                                <DialogTrigger asChild>
+                                    <div className="relative aspect-video cursor-pointer">
+                                        <Image
+                                            src={image.src}
+                                            alt={image.alt}
+                                            fill
+                                            className="rounded-lg object-cover"
+                                        />
+                                    </div>
+                                </DialogTrigger>
+                                <DialogContent className="max-w-3xl">
+                                    <div className="relative w-full h-[80vh]">
+                                        <Image
+                                            src={image.src}
+                                            alt={image.alt}
+                                            fill
+                                            className="object-contain"
+                                        />
+                                    </div>
+                                </DialogContent>
+                            </Dialog>
                         </CarouselItem>
                     ))}
                 </CarouselContent>


### PR DESCRIPTION
## Summary
- allow clicking slider images to open them in a dialog for closer view

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840bf7761cc832e95006030b08a9c4d